### PR TITLE
Fix Animal Emote and code cleanup

### DIFF
--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -1611,7 +1611,8 @@ RP.Shared = {
             SyncOffsetSide = -0.028,
             SyncOffsetHeading = 0.0
         },
-        AdultAnimation = true
+        AdultAnimation = true,
+        AnimalEmote = true
     },
     ["bdoghumping2"] = {
         "creatures@rottweiler@amb@",
@@ -1625,7 +1626,8 @@ RP.Shared = {
             SyncOffsetSide = -0.028,
             SyncOffsetHeading = 0.0
         },
-        AdultAnimation = true
+        AdultAnimation = true,
+        AnimalEmote = true
     }
 }
 

--- a/client/AnimationList.lua
+++ b/client/AnimationList.lua
@@ -16048,23 +16048,3 @@ RP.PropEmotes = {
     }
 
 }
-
--- Remove emotes if needed
-
-local emoteTypes = {
-    "Shared",
-    "Dances",
-    "AnimalEmotes",
-    "Emotes",
-    "PropEmotes",
-}
-
-for i = 1, #emoteTypes do
-    local emoteType = emoteTypes[i]
-    for emoteName, emoteData in pairs(RP[emoteType]) do
-        local shouldRemove = false
-        if Config.AdultEmotesDisabled and emoteData.AdultAnimation then shouldRemove = true end
-        if emoteData[1] and not ((emoteData[1] == 'Scenario') or (emoteData[1] == 'ScenarioObject') or (emoteData[1] == 'MaleScenario')) and not DoesAnimDictExist(emoteData[1]) then shouldRemove = true end
-        if shouldRemove then RP[emoteType][emoteName] = nil end
-    end
-end

--- a/client/AnimationListCustom.lua
+++ b/client/AnimationListCustom.lua
@@ -1,5 +1,5 @@
 -- Emotes you add in the file will automatically be added to AnimationList.lua
-local CustomDP = {}
+CustomDP = {}
 
 CustomDP.Expressions = {}
 CustomDP.Walks = {}
@@ -8,19 +8,3 @@ CustomDP.Dances = {}
 CustomDP.AnimalEmotes = {}
 CustomDP.Emotes = {}
 CustomDP.PropEmotes = {}
-
--- Add the custom emotes
-for arrayName, array in pairs(CustomDP) do
-    if RP[arrayName] then
-        for emoteName, emoteData in pairs(array) do
-            -- We don't add adult animations if not needed
-            if not emoteData.AdultAnimation or not Config.AdultEmotesDisabled then
-                RP[arrayName][emoteName] = emoteData
-            end
-        end
-    end
-    -- Free memory
-    CustomDP[arrayName] = nil
-end
--- Free memory
-CustomDP = nil

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -21,6 +21,41 @@ local AnimationThreadStatus = false
 local CanCancel = true
 local Pointing = false
 
+
+-- Add the custom emotes
+for arrayName, array in pairs(CustomDP) do
+    if RP[arrayName] then
+        for emoteName, emoteData in pairs(array) do
+            RP[arrayName][emoteName] = emoteData
+        end
+    end
+    -- Free memory
+    CustomDP[arrayName] = nil
+end
+-- Free memory
+CustomDP = nil
+
+-- Remove emotes if needed
+
+local emoteTypes = {
+    "Shared",
+    "Dances",
+    "AnimalEmotes",
+    "Emotes",
+    "PropEmotes",
+}
+
+for i = 1, #emoteTypes do
+    local emoteType = emoteTypes[i]
+    for emoteName, emoteData in pairs(RP[emoteType]) do
+        local shouldRemove = false
+        if Config.AdultEmotesDisabled and emoteData.AdultAnimation then shouldRemove = true end
+        if not Config.AnimalEmotesEnabled and emoteData.AnimalEmotes then shouldRemove = true end
+        if emoteData[1] and not ((emoteData[1] == 'Scenario') or (emoteData[1] == 'ScenarioObject') or (emoteData[1] == 'MaleScenario')) and not DoesAnimDictExist(emoteData[1]) then shouldRemove = true end
+        if shouldRemove then RP[emoteType][emoteName] = nil end
+    end
+end
+
 local function RunAnimationThread()
     if AnimationThreadStatus then return end
     AnimationThreadStatus = true

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -50,7 +50,7 @@ for i = 1, #emoteTypes do
     for emoteName, emoteData in pairs(RP[emoteType]) do
         local shouldRemove = false
         if Config.AdultEmotesDisabled and emoteData.AdultAnimation then shouldRemove = true end
-        if not Config.AnimalEmotesEnabled and emoteData.AnimalEmotes then shouldRemove = true end
+        if not Config.AnimalEmotesEnabled and emoteData.AnimalEmote then shouldRemove = true end
         if emoteData[1] and not ((emoteData[1] == 'Scenario') or (emoteData[1] == 'ScenarioObject') or (emoteData[1] == 'MaleScenario')) and not DoesAnimDictExist(emoteData[1]) then shouldRemove = true end
         if shouldRemove then RP[emoteType][emoteName] = nil end
     end

--- a/client/EmoteMenu.lua
+++ b/client/EmoteMenu.lua
@@ -35,18 +35,6 @@ function ShowNotification(text)
     end
 end
 
--- Clear all the animal emotes if disabled.
-if not Config.AnimalEmotesEnabled then
-    RP.AnimalEmotes = {}
-    for k, v in pairs(RP) do
-        for i, j in pairs(v) do
-            if j.AnimalEmote then
-                RP[k][i] = nil
-            end
-        end
-    end
-end
-
 local EmoteTable = {}
 local FavEmoteTable = {}
 local KeyEmoteTable = {}

--- a/config.lua
+++ b/config.lua
@@ -56,7 +56,7 @@ Config = {
     -- You can disable the Adult Emotes here.
     AdultEmotesDisabled = false,
     -- You can disable the Animal Emotes here.
-    AnimalEmotesEnabled = true,
+    AnimalEmotesEnabled = false,
     -- Used to enable or disable the search feature in the menu.
     Search = true,
     -- You can disable the handsup here / change the keybind. It is currently set to H


### PR DESCRIPTION
Moved check from bottom of AnimationList.lua into Emote.lua as the basic code and functions is there and it would make more sense to move working code into the file with functions and working code.

The same for AnimationLisCustom.lua, moved the merging and check code at the bottom into Emote.lua as well, at the top, and removed adult check as we already have that for the RP array, this code now just merge custom list into RP array

Finally after moving the check into Emote.lua I added the animal check after the adult check so if adult is enabled but animal emotes are not, it will remove the adult emotes tagged animal