### PR TITLE
fix/feat: enables switching emotes with same exit

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -516,7 +516,7 @@ function OnEmotePlay(EmoteName, textureVariation)
     end
 
     if ChosenAnimOptions and ChosenAnimOptions.ExitEmote then
-        if RP.Exits[ChosenAnimOptions.ExitEmote][2] ~= EmoteName[2] then
+        if not (animOption and ChosenAnimOptions.ExitEmote == animOption.ExitEmote) and RP.Exits[ChosenAnimOptions.ExitEmote][2] ~= EmoteName[2] then
             return
         end
     end


### PR DESCRIPTION
Co-authored-by: @AvaN0x 

This enables switching between similar emotes with has exact the same exit animation.