### PR TITLE
Update Emote.lua

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -91,10 +91,6 @@ if Config.EnableXtoCancel then
     RegisterKeyMapping("emotecancel", "Cancel current emote", "keyboard", Config.CancelEmoteKey)
 end
 
-if Config.HandsupKeybindEnabled then
-    RegisterKeyMapping("handsup", "Put your arms up", "keyboard", Config.HandsupKeybind)
-end
-
 -----------------------------------------------------------------------------------------------------
 -- Commands / Events --------------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -133,8 +133,8 @@ end
 RegisterCommand('emotes', function() EmotesOnCommand() end, false)
 RegisterCommand('emotecancel', function() EmoteCancel() end, false)
 
-RegisterCommand('handsup', function()
-    if Config.HandsupKeybindEnabled then
+if Config.HandsupKeybindEnabled then
+    RegisterCommand('handsup', function()
         if IsPedInAnyVehicle(PlayerPedId(), false) and not Config.HandsupKeybindInCarEnabled then
             return
         end
@@ -144,8 +144,8 @@ RegisterCommand('handsup', function()
         else
             EmoteCommandStart(nil, {"handsup"}, nil)
         end
-    end
-end, false)
+    end, false)
+end
 
 AddEventHandler('onResourceStop', function(resource)
     if resource == GetCurrentResourceName() then

--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -132,8 +132,8 @@ else
 end
 RegisterCommand('emotes', function() EmotesOnCommand() end, false)
 RegisterCommand('emotecancel', function() EmoteCancel() end, false)
-
 if Config.HandsupKeybindEnabled then
+    RegisterKeyMapping("handsup", "Put your arms up", "keyboard", Config.HandsupKeybind)
     RegisterCommand('handsup', function()
         if IsPedInAnyVehicle(PlayerPedId(), false) and not Config.HandsupKeybindInCarEnabled then
             return


### PR DESCRIPTION
Do not register the command "handsup" unless it has been enabled in the config. 

Currently the code still registers handsup and automatically messes up other handsup intergration. This removes the need to manually comment it out on every update.