### PR TITLE
feat/refactor(client/Crouch.lua): Block animal peds and allow for C key to be used.

### DIFF
--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -98,6 +98,19 @@ local function AttemptCrouch(playerPed)
     end
 end
 
+---Disables a control until it's key has been released
+---@param padIndex integer
+---@param control integer
+local function DisableControlUntilReleased(padIndex, control)
+    CreateThread(function()
+        while IsDisabledControlPressed(padIndex, control) do
+            DisableControlAction(padIndex, control, true)
+            Wait(0)
+        end
+    end)
+end
+
+-- Called when the crouch key is pressed
 local function CrouchKeyPressed()
     -- If we already are doing something, then don't continue
     if inAction then
@@ -107,6 +120,14 @@ local function CrouchKeyPressed()
     -- If crouched then stop crouching
     if isCrouched then
         isCrouched = false
+        local crouchKey = GetControlInstructionalButton(0, `+crouch` | 0x80000000, false)
+        local lookBehindKey = GetControlInstructionalButton(0, 26, false)
+
+        -- Disable look behind if the crouch and look behind keys are the same
+        if crouchKey == lookBehindKey then
+            DisableControlUntilReleased(0, 26) -- INPUT_LOOK_BEHIND
+        end
+
         return
     end
 
@@ -116,9 +137,15 @@ local function CrouchKeyPressed()
     if Config.CrouchOverride then
         DisableControlAction(0, 36, true) -- Disable INPUT_DUCK this frame
     else
-        -- Get +crouch and INPUT_DUCK keys
-        local crouchKey = GetControlInstructionalButton(0, 0xD2D0BEBA, false)
+        -- Get +crouch, INPUT_DUCK and INPUT_LOOK_BEHIND keys
+        local crouchKey = GetControlInstructionalButton(0, `+crouch` | 0x80000000, false)
         local duckKey = GetControlInstructionalButton(0, 36, false)
+        local lookBehindKey = GetControlInstructionalButton(0, 26, false)
+
+        -- Disable look behind if the crouch and look behind keys are the same
+        if crouchKey == lookBehindKey then
+            DisableControlUntilReleased(0, 26) -- INPUT_LOOK_BEHIND
+        end
 
         -- If they are the same and we aren't prone, then check if we are in stealth mode and how long ago the last button press was.
         if crouchKey == duckKey and not IsProne then

--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -89,7 +89,7 @@ local function StartCrouch()
 end
 
 local function AttemptCrouch(playerPed)
-    if CanPlayerCrouchCrawl(playerPed) then
+    if CanPlayerCrouchCrawl(playerPed) and GetPedType(playerPed) ~= 28 then
         StartCrouch()
         return true
     else
@@ -133,6 +133,11 @@ local function CrouchKeyPressed()
     -- Get the player ped
     local playerPed = PlayerPedId()
 
+    -- Check if we can actually crouch and check if we are an animal
+    if not CanPlayerCrouchCrawl(playerPed) or GetPedType(playerPed) == 28 then
+        return
+    end
+
     if Config.CrouchOverride then
         DisableControlAction(0, 36, true) -- Disable INPUT_DUCK this frame
     else
@@ -154,16 +159,18 @@ local function CrouchKeyPressed()
             if GetPedStealthMovement(playerPed) == 1 and timer - lastKeyPress < 1000 then
                 DisableControlAction(0, 36, true) -- Disable INPUT_DUCK this frame
                 lastKeyPress = 0
-                AttemptCrouch(playerPed)
+            else
+                lastKeyPress = timer
                 return
             end
-            lastKeyPress = timer
-            return
         end
     end
 
-    -- Attempt to crouch, if we were successful, then also check if we are prone, if so then play an animaiton
-    if AttemptCrouch(playerPed) and IsProne then
+    -- Start to crouch
+    StartCrouch()
+
+    -- If we are prone play an animation from prone to crouch
+    if IsProne then
         inAction = true
         IsProne = false
         PlayAnimOnce(playerPed, "get_up@directional@transition@prone_to_knees@crawl", "front", nil, nil, 780)
@@ -377,7 +384,7 @@ local function CrawlKeyPressed()
     end
 
     local playerPed = PlayerPedId()
-    if not CanPlayerCrouchCrawl(playerPed) or IsEntityInWater(playerPed) then
+    if not CanPlayerCrouchCrawl(playerPed) or IsEntityInWater(playerPed) or GetPedType(playerPed) == 28 then
         return
     end
 

--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -89,7 +89,7 @@ local function StartCrouch()
 end
 
 local function AttemptCrouch(playerPed)
-    if CanPlayerCrouchCrawl(playerPed) and GetPedType(playerPed) ~= 28 then
+    if CanPlayerCrouchCrawl(playerPed) and IsPedHuman(playerPed) then
         StartCrouch()
         return true
     else
@@ -134,7 +134,7 @@ local function CrouchKeyPressed()
     local playerPed = PlayerPedId()
 
     -- Check if we can actually crouch and check if we are an animal
-    if not CanPlayerCrouchCrawl(playerPed) or GetPedType(playerPed) == 28 then
+    if not CanPlayerCrouchCrawl(playerPed) or not IsPedHuman(playerPed) then
         return
     end
 
@@ -384,7 +384,7 @@ local function CrawlKeyPressed()
     end
 
     local playerPed = PlayerPedId()
-    if not CanPlayerCrouchCrawl(playerPed) or IsEntityInWater(playerPed) or GetPedType(playerPed) == 28 then
+    if not CanPlayerCrouchCrawl(playerPed) or IsEntityInWater(playerPed) or not IsPedHuman(playerPed) then
         return
     end
 

--- a/client/Crouch.lua
+++ b/client/Crouch.lua
@@ -6,7 +6,6 @@ local proneType = "onfront"
 local lastKeyPress = 0
 
 
-
 -- Crouching --
 local function ResetCrouch()
     local playerPed = PlayerPedId()
@@ -381,6 +380,7 @@ local function CrawlKeyPressed()
     if not CanPlayerCrouchCrawl(playerPed) or IsEntityInWater(playerPed) then
         return
     end
+
     inAction = true
 
     -- If we are pointing then stop pointing

--- a/client/Utils.lua
+++ b/client/Utils.lua
@@ -32,8 +32,7 @@ end
 
 function PlayAnimOnce(playerPed, animDict, animName, blendInSpeed, blendOutSpeed, duration, startTime)
     LoadAnim(animDict)
-    TaskPlayAnim(playerPed, animDict, animName, blendInSpeed or 2.0, blendOutSpeed or 2.0, duration or -1, 0,
-        startTime or 0.0, false, false, false)
+    TaskPlayAnim(playerPed, animDict, animName, blendInSpeed or 2.0, blendOutSpeed or 2.0, duration or -1, 0, startTime or 0.0, false, false, false)
     RemoveAnimDict(animDict)
 end
 


### PR DESCRIPTION
Blocks player with animal peds from using crouch/crawl as it won't work or looks really bad.

Also blocks INPUT_LOOK_BEHIND (key: C) if the crouch key is set to the same by the player.

This should be tested more before it's merged.