### PR TITLE
pointing in vehicle config

### DIFF
--- a/client/Pointing.lua
+++ b/client/Pointing.lua
@@ -122,6 +122,9 @@ end
 -- Commands & KeyMapping --
 if Config.PointingEnabled then
     RegisterCommand('pointing', function()
+        if IsPedInAnyVehicle(PlayerPedId(), false) and not Config.PointingKeybindInCarEnabled then
+            return
+        end
         StartPointing()
     end, false)
 

--- a/config.lua
+++ b/config.lua
@@ -75,6 +75,7 @@ Config = {
     PointingEnabled = false,
     PointingKeybindEnabled = true,
     PointingKeybind = 'B', -- Get the button string here https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard/
+    PointingKeybindInCarEnabled = false,
     PersistentEmoteAfterPointing = true, -- If true, you will play the emote you were playing previously after you stop pointing.
     -- If crouching should be enabled.
     CrouchEnabled = true,


### PR DESCRIPTION
This allows servers to have the choice for players to point in vehicles or not...

Most servers use B for their seatbelt and B to point, so this allows them to disable pointing in the vehicle