### PR TITLE
[FIX] Readded removal of adult emotes when AdultEmotesDisabled it set

### DIFF
--- a/client/Emote.lua
+++ b/client/Emote.lua
@@ -46,6 +46,7 @@ for i = 1, #emoteTypes do
     local emoteType = emoteTypes[i]
     for emoteName, emoteData in pairs(RP[emoteType]) do
         local shouldRemove = false
+        if Config.AdultEmotesDisabled and emoteData.AdultAnimation then shouldRemove = true end
         if emoteData[1] and not ((emoteData[1] == 'Scenario') or (emoteData[1] == 'ScenarioObject') or (emoteData[1] == 'MaleScenario')) and not DoesAnimDictExist(emoteData[1]) then shouldRemove = true end
         if shouldRemove then RP[emoteType][emoteName] = nil end
     end


### PR DESCRIPTION
The check that removes adult emotes went missing here: https://github.com/TayMcKenzieNZ/rpemotes/commit/71f157e1d24422146540700570d423cee4a7290e

This results in adult emotes still being shown in the menu even if deactivated.
Readding the missing line fixes this.